### PR TITLE
Add interface to global application config

### DIFF
--- a/sources/main/main.config.ts
+++ b/sources/main/main.config.ts
@@ -7,7 +7,7 @@ module app {
    */
   function mainConfig($provide: ng.auto.IProvideService,
                       $compileProvider: ng.ICompileProvider,
-                      config: any) {
+                      config: IApplicationConfig) {
 
     // Extend the $exceptionHandler service to output logs.
     $provide.decorator('$exceptionHandler', ($delegate: any, $injector: any) => {

--- a/sources/main/main.constants.ts
+++ b/sources/main/main.constants.ts
@@ -2,6 +2,17 @@ module app {
 
   'use strict';
 
+  export interface IApplicationConfig {
+    version: string;
+    environment: IApplicationEnvironment;
+    supportedLanguages: Array<string>;
+  }
+
+  export interface IApplicationEnvironment {
+    debug: boolean;
+    server: IServerConfig;
+  }
+
   // Do not remove the comments below, or change the values. It's the markers used by gulp build task to change the
   // value of the config constant when building the application, while removing the code below for all environments.
   // replace:environment
@@ -25,12 +36,7 @@ module app {
   };
   // endreplace
 
-  /**
-   * Defines app-level configuration.
-   */
-  angular
-    .module('app')
-    .constant('config', {
+  let config : IApplicationConfig = {
 
       // Do not remove the comments below, or change the values. It's the markers used by gulp build task to inject app
       // version from package.json and environment values.
@@ -45,6 +51,13 @@ module app {
         'fr-FR'
       ]
 
-    });
+    };
+
+  /**
+   * Defines app-level configuration.
+   */
+  angular
+    .module('app')
+    .constant('config', config);
 
 }

--- a/sources/main/main.run.ts
+++ b/sources/main/main.run.ts
@@ -12,7 +12,7 @@ module app {
                 $state: angular.ui.IStateService,
                 gettextCatalog: angular.gettext.gettextCatalog,
                 _: _.LoDashStatic,
-                config: any,
+                config: IApplicationConfig,
                 restService: RestService) {
 
     /*

--- a/sources/modules/screens/about/about.controller.ts
+++ b/sources/modules/screens/about/about.controller.ts
@@ -12,7 +12,7 @@ module app {
     private logger: ILogger;
 
     constructor(logger: LoggerService,
-                config: any) {
+                config: IApplicationConfig) {
 
       this.logger = logger.getLogger('about');
       this.version = config.version;

--- a/sources/modules/shell/shell.controller.ts
+++ b/sources/modules/shell/shell.controller.ts
@@ -18,7 +18,7 @@ module app {
                 $locale: ng.ILocaleService,
                 private _: _.LoDashStatic,
                 logger: LoggerService,
-                config: any) {
+                config: IApplicationConfig) {
 
       this.currentLocale = $locale;
       this.logger = logger.getLogger('shell');


### PR DESCRIPTION
Here is a PR to add an interface to the global application config so that we can have type annotations when we inject configuration into services or controllers.

I wasn't sure if it was a good idea to move IServerConfig from the rest.service.ts file. It's a bit weird right now because of circular dependencies: we define IApplicationConfig in main.constants.ts that needs IServerConfig and IServerConfig is defined in rest.service.ts that needs IApplicationConfig.