### PR TITLE
Google Analytics helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ npm-debug.log
 ## IntelliJ / WebStorm
 *.iml
 *.iws
-.idea/*
+.idea/
 !.idea/runConfigurations/
 !.idea/codeStyleSettings.xml
 

--- a/sources/main/main.constants.ts
+++ b/sources/main/main.constants.ts
@@ -6,6 +6,7 @@ module app {
     version: string;
     environment: IApplicationEnvironment;
     supportedLanguages: Array<string>;
+    analyticsAccount: string;
   }
 
   export interface IApplicationEnvironment {
@@ -52,7 +53,11 @@ module app {
     supportedLanguages: [
       'en-US',
       'fr-FR'
-    ]
+    ],
+
+    // Google Analytics account. Leave null to not have any analytics active.
+    // Typical values take the form 'UA-########-1'.
+    analyticsAccount: null
 
   };
 

--- a/sources/main/main.run.ts
+++ b/sources/main/main.run.ts
@@ -8,12 +8,14 @@ module app {
    */
   function main($window: ng.IWindowService,
                 $locale: ng.ILocaleService,
+                $location: ng.ILocationService,
                 $rootScope: any,
                 $state: angular.ui.IStateService,
                 gettextCatalog: angular.gettext.gettextCatalog,
                 _: _.LoDashStatic,
                 config: IApplicationConfig,
-                restService: RestService) {
+                restService: RestService,
+                analyticsService: AnalyticsService) {
 
     /*
      * Root view model
@@ -56,6 +58,21 @@ module app {
      */
     vm.$on('gettextLanguageChanged', () => {
       updateTitle($state.current.data ? $state.current.data.title : null);
+    });
+
+    /**
+     * Enables tracking by analytics service.
+     */
+    // HACK : ignore the first $viewContentLoaded event because it's actually fired once when uiView is instantiated,
+    // and then it's fired a second time after is has been linked. This is "by design" :-/
+    // (http://stackoverflow.com/questions/31000417/angular-js-viewcontentloaded-loading-twice-on-initial-homepage-load)
+    let loadedOnce = false;
+    vm.$on('$viewContentLoaded', function () {
+      if (!loadedOnce) {
+        loadedOnce = true;
+      } else if (analyticsService) {
+        analyticsService.trackPage($location.url());
+      }
     });
 
     init();

--- a/sources/modules/helpers/analytics/analytics.service.ts
+++ b/sources/modules/helpers/analytics/analytics.service.ts
@@ -1,0 +1,74 @@
+module app {
+
+  'use strict';
+
+  /**
+   * Analytics service: insert Google Analytics library in the page.
+   */
+  export class AnalyticsService {
+
+    private analyticsAreActive = false;
+
+    constructor(private $window: ng.IWindowService,
+                private config: IApplicationConfig,
+                logger: LoggerService) {
+
+      this.logger = logger.getLogger('cacheService');
+
+      this.init();
+    }
+
+    private createGoogleAnalyticsObject(i, s, o, g, r, a?, m?) {
+      i.GoogleAnalyticsObject = r;
+      i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments);
+      };
+      i[r].l = new Date();
+      a = s.createElement(o);
+      m = s.getElementsByTagName(o)[0];
+      a.async = 1;
+      a.src = g;
+      m.parentNode.insertBefore(a, m);
+    }
+
+    /**
+     * Tracks a page change in google analytics.
+     * @param {String} url The url of the new page.
+     */
+    trackPage (url: string) {
+      if (this.analyticsAreActive) {
+        var urlWithoutParams = url;
+        var split = url.split('?');
+        if (split.length > 1) {
+          urlWithoutParams = split[0];
+        }
+        this.$window.googleAnalytics('send', 'pageview', urlWithoutParams);
+      }
+    }
+
+    /**
+     * Sends a track event to google analytics.
+     * @param {String} category The category to be sent.
+     * @param {String} action The action to be sent.
+     * @param {String=} label The label to be sent.
+     */
+    trackEvent (category: string, action: string, label?: string) {
+      if (this.analyticsAreActive) {
+        this.$window.googleAnalytics('send', 'event', category, action, label);
+      }
+    }
+
+    init(): void {
+      if (config.analyticsAccount !== null) {
+        var analyticsScriptUrl = '//www.google-analytics.com/analytics.js';
+        this.createGoogleAnalyticsObject(window, document, 'script', analyticsScriptUrl, 'googleAnalytics');
+        this.$window.googleAnalytics('create', config.analyticsAccount, 'auto');
+        this.analyticsAreActive = true;
+      }
+    }
+  }
+
+  angular
+    .module('app')
+    .factory('analyticsService', AnalyticsService);
+}


### PR DESCRIPTION
Added analytics service in /helpers. This services supports basic page tracking (automatically triggered on view change, so the method never has to be called manually) and event tracking.